### PR TITLE
chore: prepare next release 1.0.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 release:
-  current-version: "0"
-  next-version: "1.0.0-SNAPSHOT"
+  current-version: "1.0.0"
+  next-version: "999-SNAPSHOT"
 


### PR DESCRIPTION
Prepare quarkus-sshd for the next release `1.0.0`.
~~Versioning scheme proposal: `2.10.0.0` where `2.10.0` is the upstream sshd version and the last `.0` is the increment for this extension.~~
